### PR TITLE
Fixes references to expecterd arrays from API responses due to new TestRail 7.2 version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ const prepareRun = async (
     const { value: tests } = await throwOnApiError(
       testrailAPI.getTests(existingRun.id)
     );
-    const currentCaseIds = tests?.map((test) => test.case_id) || [];
+    const currentCaseIds = tests?.tests.map((test) => test.case_id) || [];
     const additionalDescription = "\n" + runDescription;
     const newDescription = existingRun.description
       ? existingRun.description.replace(additionalDescription, "") +
@@ -240,7 +240,7 @@ class TestcafeTestrailReporter {
           const { value: caseList } = await throwOnApiError(
             testrailAPI.getCases(projectId, { suite_id: suiteId })
           );
-          const existingCaseIds = caseList.map((item) => item.id);
+          const existingCaseIds = caseList.cases.map((item) => item.id);
 
           caseIdList.forEach((id) => {
             if (!existingCaseIds.includes(id)) {


### PR DESCRIPTION
## Scope
Point to the new property that contains the expected array of objects in different API call responses.

## Context:
API responses for `getTests` and `getCases` now contain the array objects under the property `tests` and `cases` respectively.